### PR TITLE
Added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.13.2-slim
+
+WORKDIR /app
+
+RUN apt update && apt install -y libmagic-dev && rm -rf /var/lib/apt/lists/*
+
+COPY docker-requirements.txt .
+RUN pip install --no-cache-dir -r docker-requirements.txt
+
+COPY . .
+EXPOSE 5000
+CMD ["python3", "web_app.py"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ The analysis provides:
 - Modern web browser
 - Dependencies listed in requirements.txt
 
+## Docker
+
+The application can also be run as a docker image. See [`docker-compose.yml`](./docker-compose.yml) for an example usage. Mount the volumes you'd like to browse in the docker container and start it with
+
+```sh
+docker compose up
+```
+
 ## Privacy Note
 
 The folder history feature stores data locally and is not included in Git commits. The `.gitignore` file ensures your analysis history remains private. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  folderanalyzer:
+    build:
+      context: .
+    ports:
+      - 3323:5000
+    volumes:
+      - .:/mnt/test:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,6 @@ services:
     build:
       context: .
     ports:
-      - 3323:5000
+      - 5000:5000
     volumes:
       - .:/mnt/test:ro

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -1,0 +1,4 @@
+flask==3.0.2
+flask-cors==4.0.0
+chardet==5.2.0
+python-magic==0.4.27

--- a/web_app.py
+++ b/web_app.py
@@ -186,4 +186,4 @@ def cancel_analysis():
 if __name__ == '__main__':
     # Create templates directory if it doesn't exist
     Path('templates').mkdir(exist_ok=True)
-    app.run(debug=True, port=5000, use_debugger=False) 
+    app.run(debug=True, port=5000, use_debugger=False, host='0.0.0.0') 


### PR DESCRIPTION
- added dockerfile
- added sample docker compose file

Note: to get it running in docker I had to 1) set the flask host to `0.0.0.0` and 2) use `python-magic` instead of `python-magic-bin`. To preserve the original `requirements.txt` I created `docker-requirements.txt` specifically for the docker image.